### PR TITLE
Update SfxrParams.as

### DIFF
--- a/src/com/increpare/bfxr/synthesis/Synthesizer/SfxrParams.as
+++ b/src/com/increpare/bfxr/synthesis/Synthesizer/SfxrParams.as
@@ -1,12 +1,12 @@
-package com.increpare.bfxr.synthesis.Synthesizer   
+package com.increpare.bfxr.synthesis.Synthesizer
 {
 	import com.increpare.bfxr.synthesis.ISerializable;
-	
+
 	import mx.utils.StringUtil;
 
 	/**
 	 * SfxrParams
-	 * 
+	 *
 	 * Copyright 2010 Thomas Vian
 	 *
 	 * Licensed under the Apache License, Version 2.0 (the "License");
@@ -20,7 +20,7 @@ package com.increpare.bfxr.synthesis.Synthesizer
 	 * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 	 * See the License for the specific language governing permissions and
 	 * limitations under the License.
-	 * 
+	 *
 	 * @author Thomas Vian
 	 */
 	public class SfxrParams implements ISerializable
@@ -30,139 +30,139 @@ package com.increpare.bfxr.synthesis.Synthesizer
 		//  Properties
 		//
 		//--------------------------------------------------------------------------
-		
+
 		/** If the parameters have been changed since last time (shouldn't used cached sound) */
-		public var paramsDirty:Boolean;			
-		
+		public var paramsDirty:Boolean;
+
 		//interface uses this to disable square sliders when non-square wavetype selected
 		public static const SquareParams:Array = ["squareDuty","dutySweep"];
-		
+
 		//params to exclude from list
 		public static const ExcludeParams:Array = ["waveType","masterVolume"];
-		
+
 		public static const ParamData:Array = [
 		// real name, decription
-		//   grouping,name, default, min, max, 
+		//   grouping,name, default, min, max,
 		["Wave Type","Shape of the wave.",
-			0,"waveType",2,0,WAVETYPECOUNT-0.0001], // the 6.999 thing is because this is really an int parameter...		
-		
+			0,"waveType",2,0,WAVETYPECOUNT-0.0001], // the 6.999 thing is because this is really an int parameter...
+
 		["Master Volume","Overall volume of the sound.",
-			1,"masterVolume",0.5,0,1], 	
+			1,"masterVolume",0.5,0,1],
 		["Attack Time","Length of the volume envelope attack.",
-			1,"attackTime",0,0,1],		
+			1,"attackTime",0,0,1],
 		["Sustain Time","Length of the volume envelope sustain.",
-			1,"sustainTime",0.3,0,1], 	
+			1,"sustainTime",0.3,0,1],
 		["Punch","Tilts the sustain envelope for more 'pop'.",
-			1,"sustainPunch",0,0,1], 		
+			1,"sustainPunch",0,0,1],
 		["Decay Time","Length of the volume envelope decay (yes, I know it's called release).",
-			1,"decayTime",0.4,0,1], 	
-		
+			1,"decayTime",0.4,0,1],
+
 		["Compression","Pushes amplitudes together into a narrower range to make them stand out more.  Very good for sound effects, where you want them to stick out against background music.",
 			15,"compressionAmount",0.3,0,1],
-		
+
 		["Frequency","Base note of the sound.",
-			2,"startFrequency",0.3,0,1], 		
+			2,"startFrequency",0.3,0,1],
 		["Frequency Cutoff","If sliding, the sound will stop at this frequency, to prevent really low notes.  If unlocked, this is set to zero during randomization.",
-			2,"minFrequency",0.0,0,1], 		
-		
+			2,"minFrequency",0.0,0,1],
+
 		["Frequency Slide","Slides the frequency up or down.",
-			3,"slide",0.0,-1,1], 	
+			3,"slide",0.0,-1,1],
 		["Delta Slide","Accelerates the frequency slide.  Can be used to get the frequency to change direction.",
-			3,"deltaSlide",0.0,-1,1], 		
-		
+			3,"deltaSlide",0.0,-1,1],
+
 		["Vibrato Depth","Strength of the vibrato effect.",
-			4,"vibratoDepth",0,0,1], 		
+			4,"vibratoDepth",0,0,1],
 		["Vibrato Speed","Speed of the vibrato effect (i.e. frequency).",
-			4,"vibratoSpeed",0,0,1], 		
-		
+			4,"vibratoSpeed",0,0,1],
+
 		["Harmonics","Overlays copies of the waveform with copies and multiples of its frequency.  Good for bulking out or otherwise enriching the texture of the sounds (warning: this is the number 1 cause of bfxr slowdown!).",
-			13,"overtones",0,0,1], 		
+			13,"overtones",0,0,1],
 		["Harmonics Falloff","The rate at which higher overtones should decay.",
-			13,"overtoneFalloff",0,0,1], 
-		
+			13,"overtoneFalloff",0,0,1],
+
 		["Pitch Jump Repeat Speed","Larger Values means more pitch jumps, which can be useful for arpeggiation.",
-			5,"changeRepeat",0,0,1], 		
-		
+			5,"changeRepeat",0,0,1],
+
 		["Pitch Jump Amount 1","Jump in pitch, either up or down.",
-			5,"changeAmount",0,-1,1], 		
+			5,"changeAmount",0,-1,1],
 		["Pitch Jump Onset 1","How quickly the note shift happens.",
-			5,"changeSpeed",0,0,1], 		
-		
+			5,"changeSpeed",0,0,1],
+
 		["Pitch Jump Amount 2","Jump in pitch, either up or down.",
-			5,"changeAmount2",0,-1,1], 	
+			5,"changeAmount2",0,-1,1],
 		["Pitch Jump Onset 2","How quickly the note shift happens.",
-			5,"changeSpeed2",0,0,1], 		
-		
+			5,"changeSpeed2",0,0,1],
+
 		["Square Duty","Square waveform only : Controls the ratio between the up and down states of the square wave, changing the tibre.",
-			8,"squareDuty",0,0,1], 		
+			8,"squareDuty",0,0,1],
 		["Duty Sweep","Square waveform only : Sweeps the duty up or down.",
-			8,"dutySweep",0,-1,1], 		
-		
+			8,"dutySweep",0,-1,1],
+
 		["Repeat Speed","Speed of the note repeating - certain variables are reset each time.",
-			9,"repeatSpeed",0,0,1], 	
-		
+			9,"repeatSpeed",0,0,1],
+
 		["Flanger Offset","Offsets a second copy of the wave by a small phase, changing the tibre.",
-			10,"flangerOffset",0,-1,1], 		
+			10,"flangerOffset",0,-1,1],
 		["Flanger Sweep","Sweeps the phase up or down.",
-			10,"flangerSweep",0,-1,1], 
-		
+			10,"flangerSweep",0,-1,1],
+
 		["Low-pass Filter Cutoff","Frequency at which the low-pass filter starts attenuating higher frequencies.  Named most likely to result in 'Huh why can't I hear anything?' at her high-school grad. ",
-			11,"lpFilterCutoff",1,0,1], 		
+			11,"lpFilterCutoff",1,0,1],
 		["Low-pass Filter Cutoff Sweep","Sweeps the low-pass cutoff up or down.",
-			11,"lpFilterCutoffSweep",0,-1,1], 	
+			11,"lpFilterCutoffSweep",0,-1,1],
 		["Low-pass Filter Resonance","Changes the attenuation rate for the low-pass filter, changing the timbre.",
-			11,"lpFilterResonance",0,0,1], 		
-		
+			11,"lpFilterResonance",0,0,1],
+
 		["High-pass Filter Cutoff","Frequency at which the high-pass filter starts attenuating lower frequencies.",
-			12,"hpFilterCutoff",0,0,1], 	
+			12,"hpFilterCutoff",0,0,1],
 		["High-pass Filter Cutoff Sweep","Sweeps the high-pass cutoff up or down.",
-			12,"hpFilterCutoffSweep",0,-1,1], 	
-						
+			12,"hpFilterCutoffSweep",0,-1,1],
+
 		["Bit Crush","Resamples the audio at a lower frequency.",
 			14,"bitCrush",0,0,1] ,
 		["Bit Crush Sweep","Sweeps the Bit Crush filter up or down.",
-			14,"bitCrushSweep",0,-1,1]  
-		
+			14,"bitCrushSweep",0,-1,1]
+
 		];
-		
+
 		private var _params:Object; // stores values for all the parameters above
 		private var _lockedParams : Vector.<String>; // stores list of strings, these strings represent parameters that will be locked during randomization/mutation
-		
+
 		//--------------------------------------------------------------------------
 		//
 		//  Getters / Setters
 		//
 		//--------------------------------------------------------------------------
-		
+
 		public static const WAVETYPECOUNT:int = 9;
-		
+
 		public function SfxrParams()
 		{
-			//initialize param object 
-			_params = new Object();			
+			//initialize param object
+			_params = new Object();
 			for (var i:int=0;i<ParamData.length;i++)
 			{
 				_params[ParamData[i][3]]=-100;
 			}
-			
+
 			resetParams();
 		}
-		
+
 		public function getDefault(param:String):Number
 		{
 			return getProperty(param,4);
 		}
-		
+
 		public function getMin(param:String):Number
 		{
 			return getProperty(param,5);
 		}
-		
+
 		public function getMax(param:String):Number
 		{
 			return getProperty(param,6);
 		}
-		
+
 		private function getProperty(param:String,index:int):Number
 		{
 			for (var i:int=0;i<ParamData.length;i++)
@@ -172,40 +172,40 @@ package com.increpare.bfxr.synthesis.Synthesizer
 					return ParamData[i][index];
 				}
 			}
-			throw new Error("Could not find param with name " + param );			
+			throw new Error("Could not find param with name " + param );
 		}
-		
+
 		public function getParam(param:String):Number
 		{
 			if (! (param in _params))
 			{
 				throw new Error("Could not get param.  Param not found " + param);
 			}
-			
-			return _params[param];			
+
+			return _params[param];
 		}
-		
+
 		public function setParam(param:String,value:Number):void
 		{
 			if (! (param in _params))
 			{
 				throw new Error("Could not set param.  Param not found " + param);
 			}
-			
+
 			_params[param]=clamp(value,getMin(param),getMax(param));
 			paramsDirty = true;
 		}
-		
+
 		/** Returns true if this parameter is locked */
 		public function lockedParam(param:String):Boolean
 		{
 			return _lockedParams.indexOf(param)>=0;
 		}
-		
+
 		public function setAllLocked(locked:Boolean):void
 		{
 			_lockedParams = new Vector.<String>();
-			
+
 			if (locked)
 			{
 				for (var i:int=0;i<ParamData.length;i++)
@@ -215,11 +215,11 @@ package com.increpare.bfxr.synthesis.Synthesizer
 			}
 			paramsDirty=true;
 		}
-		
+
 		public function setParamLocked(param:String, locked:Boolean):void
 		{
 			var index:int = _lockedParams.indexOf(param);
-			
+
 			if (locked)
 			{
 				if (index==-1)
@@ -237,69 +237,128 @@ package com.increpare.bfxr.synthesis.Synthesizer
 				}
 			}
 		}
-		
+
 		//--------------------------------------------------------------------------
 		//
 		//  Generator Methods
 		//
 		//--------------------------------------------------------------------------
-		
+
 		/**
 		 * Sets the parameters to generate a pickup/coin sound
 		 */
 		public function generatePickupCoin():void
 		{
 			resetParams();
-			
+
+                        var wave:int = int(Math.random()*7);
+                        switch (wave)  // Use every wave type, except white or pink noise
+                        {
+                                case 0:
+                                setParam("waveType", 0);
+                                setParam("squareDuty", Math.random() * 0.6);
+                                break;
+
+                                case 1:
+                                setParam("waveType", 1);
+                                break;
+
+                                case 2:
+                                setParam("waveType", 2);
+                                break;
+
+                                case 3:
+                                setParam("waveType", 4);
+                                break;
+
+                                case 4:
+                                setParam("waveType", 6);
+                                break;
+
+                                case 5:
+                                setParam("waveType", 7);
+                                break;
+
+                                case 6:
+                                setParam("waveType", 8);
+                                break;
+                        }
+
 			setParam("startFrequency",0.4+Math.random()*0.5);
-			
+
 			setParam("sustainTime", Math.random() * 0.1);
 			setParam("decayTime", 0.1 + Math.random() * 0.4);
 			setParam("sustainPunch", 0.3 + Math.random() * 0.3);
-			
-			if(Math.random() < 0.5) 
+
+			if(Math.random() < 0.5)
 			{
 				setParam("changeSpeed", 0.5 + Math.random() * 0.2);
 				var cnum:int = int(Math.random()*7)+1;
 				var cden:int = cnum+int(Math.random()*7)+2;
-				
+
 				setParam("changeAmount", Number(cnum)/Number(cden));
 			}
-			
+
 		}
-		
+
 		/**
 		 * Sets the parameters to generate a laser/shoot sound
 		 */
 		public function generateLaserShoot():void
 		{
 			resetParams();
-			
-			setParam("waveType",uint(Math.random() * 3));
-			if( int(getParam("waveType")) == 2 && Math.random() < 0.5) 
-			{
-				setParam("waveType", 
-					uint(Math.random() * 2));
-			}
-			
-			setParam("startFrequency", 
+
+                        var wave:int = int(Math.random()*7);
+                        switch (wave)  // Use every wave type, except white or pink noise
+                        {
+                                case 0:
+                                setParam("waveType", 0);
+                                setParam("squareDuty", Math.random() * 0.6);
+                                break;
+
+                                case 1:
+                                setParam("waveType", 1);
+                                break;
+
+                                case 2:
+                                setParam("waveType", 2);
+                                break;
+
+                                case 3:
+                                setParam("waveType", 4);
+                                break;
+
+                                case 4:
+                                setParam("waveType", 6);
+                                break;
+
+                                case 5:
+                                setParam("waveType", 7);
+                                break;
+
+                                case 6:
+                                setParam("waveType", 8);
+                                break;
+                        }
+
+			setParam("startFrequency",
 				0.5 + Math.random() * 0.5);
-			setParam("minFrequency", 
+			setParam("minFrequency",
 				getParam("startFrequency") - 0.2 - Math.random() * 0.6);
-			
-			if(getParam("minFrequency") < 0.2) 
+
+			if(getParam("minFrequency") < 0.2)
 				setParam("minFrequency",0.2);
-			
-			setParam("slide", -0.15 - Math.random() * 0.2);			
-			 
+
+			setParam("slide", -0.15 - Math.random() * 0.2);
+
 			if(Math.random() < 0.33)
 			{
 				setParam("startFrequency", Math.random() * 0.6);
 				setParam("minFrequency", Math.random() * 0.1);
 				setParam("slide", -0.35 - Math.random() * 0.3);
 			}
-			
-			if(Math.random() < 0.5) 
+
+			if(Math.random() < 0.5)
 			{
 				setParam("squareDuty", Math.random() * 0.5);
 				setParam("dutySweep", Math.random() * 0.2);
@@ -307,30 +366,39 @@ package com.increpare.bfxr.synthesis.Synthesizer
 			else
 			{
 				setParam("squareDuty", 0.4 + Math.random() * 0.5);
-				setParam("dutySweep",- Math.random() * 0.7);	
+				setParam("dutySweep",- Math.random() * 0.7);
 			}
-			
+
 			setParam("sustainTime", 0.1 + Math.random() * 0.2);
 			setParam("decayTime", Math.random() * 0.4);
 			if(Math.random() < 0.5) setParam("sustainPunch", Math.random() * 0.3);
-			
+
 			if(Math.random() < 0.33)
 			{
 				setParam("flangerOffset", Math.random() * 0.2);
 				setParam("flangerSweep", -Math.random() * 0.2);
 			}
-			
+
 			if(Math.random() < 0.5) setParam("hpFilterCutoff", Math.random() * 0.3);
 		}
-		
+
 		/**
 		 * Sets the parameters to generate an explosion sound
 		 */
 		public function generateExplosion():void
 		{
 			resetParams();
-			setParam("waveType", 3);
-			
+
+                        //  Use white or pink noise
+                        if(Math.random() < 0.5)
+			{
+				setParam("waveType", 3);
+			}
+                        else
+                        {
+                                setParam("waveType", 5);
+                        }
+
 			if(Math.random() < 0.5)
 			{
 				setParam("startFrequency", 0.1 + Math.random() * 0.4);
@@ -341,39 +409,69 @@ package com.increpare.bfxr.synthesis.Synthesizer
 				setParam("startFrequency", 0.2 + Math.random() * 0.7);
 				setParam("slide", -0.2 - Math.random() * 0.2);
 			}
-			
+
 			setParam("startFrequency", getParam("startFrequency") * getParam("startFrequency"));
-			
+
 			if(Math.random() < 0.2) setParam("slide", 0.0);
 			if(Math.random() < 0.33) setParam("repeatSpeed", 0.3 + Math.random() * 0.5);
-			
+
 			setParam("sustainTime", 0.1 + Math.random() * 0.3);
 			setParam("decayTime", Math.random() * 0.5);
 			setParam("sustainPunch", 0.2 + Math.random() * 0.6);
-			
+
 			if(Math.random() < 0.5)
 			{
 				setParam("flangerOffset", -0.3 + Math.random() * 0.9);
 				setParam("flangerSweep", -Math.random() * 0.3);
 			}
-			
+
 			if(Math.random() < 0.33)
 			{
 				setParam("changeSpeed", 0.6 + Math.random() * 0.3);
 				setParam("changeAmount", 0.8 - Math.random() * 1.6);
 			}
 		}
-		
+
 		/**
 		 * Sets the parameters to generate a powerup sound
 		 */
 		public function generatePowerup():void
 		{
 			resetParams();
-			
-			if(Math.random() < 0.5) setParam("waveType", 1);
-			else 					setParam("squareDuty", Math.random() * 0.6);
-			
+
+                        var wave:int = int(Math.random()*7);
+                        switch (wave)  // Use every wave type, except white and pink noise
+                        {
+                                case 0:
+                                setParam("waveType", 0);
+                                setParam("squareDuty", Math.random() * 0.6);
+                                break;
+
+                                case 1:
+                                setParam("waveType", 1);
+                                break;
+
+                                case 2:
+                                setParam("waveType", 2);
+                                break;
+
+                                case 3:
+                                setParam("waveType", 4);
+                                break;
+
+                                case 4:
+                                setParam("waveType", 6);
+                                break;
+
+                                case 5:
+                                setParam("waveType", 7);
+                                break;
+
+                                case 6:
+                                setParam("waveType", 8);
+                                break;
+                        }
+
 			if(Math.random() < 0.5)
 			{
 				setParam("startFrequency", 0.2 + Math.random() * 0.3);
@@ -384,110 +482,201 @@ package com.increpare.bfxr.synthesis.Synthesizer
 			{
 				setParam("startFrequency", 0.2 + Math.random() * 0.3);
 				setParam("slide", 0.05 + Math.random() * 0.2);
-				
+
 				if(Math.random() < 0.5)
 				{
 					setParam("vibratoDepth", Math.random() * 0.7);
 					setParam("vibratoSpeed", Math.random() * 0.6);
 				}
 			}
-			
+
 			setParam("sustainTime", Math.random() * 0.4);
 			setParam("decayTime", 0.1 + Math.random() * 0.4);
 		}
-		
+
 		/**
 		 * Sets the parameters to generate a hit/hurt sound
 		 */
 		public function generateHitHurt():void
 		{
 			resetParams();
-			
-			setParam("waveType", uint(Math.random() * 3));
-			if(int(getParam("waveType")) == 2) 
-				setParam("waveType", 3);
-			else if(int(getParam("waveType")) == 0) 
-				setParam("squareDuty", Math.random() * 0.6);
-			
+
+                        var wave:int = int(Math.random()*9);
+                        switch (wave)  // Use every wave type
+                        {
+                                case 0:
+                                setParam("waveType", 0);
+                                setParam("squareDuty", Math.random() * 0.6);
+                                break;
+
+                                case 1:
+                                setParam("waveType", 1);
+                                break;
+
+                                case 2:
+                                setParam("waveType", 2);
+                                break;
+
+                                case 3:
+                                setParam("waveType", 3);
+                                break;
+
+                                case 4:
+                                setParam("waveType", 4);
+                                break;
+
+                                case 5:
+                                setParam("waveType", 5);
+                                break;
+
+                                case 6:
+                                setParam("waveType", 6);
+                                break;
+
+                                case 7:
+                                setParam("waveType", 7);
+                                break;
+
+                                case 8:
+                                setParam("waveType", 8);
+                                break;
+                        }
+
 			setParam("startFrequency", 0.2 + Math.random() * 0.6);
 			setParam("slide", -0.3 - Math.random() * 0.4);
-			
+
 			setParam("sustainTime", Math.random() * 0.1);
 			setParam("decayTime", 0.1 + Math.random() * 0.2);
-			
+
 			if(Math.random() < 0.5) setParam("hpFilterCutoff", Math.random() * 0.3);
 		}
-		
+
 		/**
 		 * Sets the parameters to generate a jump sound
 		 */
 		public function generateJump():void
 		{
 			resetParams();
-			
-			setParam("waveType", 0);
-			setParam("squareDuty", Math.random() * 0.6);
+
+                        var wave:int = int(Math.random()*6);
+                        switch (wave)  // Use every wave type, except white noise, pink noise, or tan
+                        {
+                                case 0:
+                                setParam("waveType", 0);
+                                setParam("squareDuty", Math.random() * 0.6);
+                                break;
+
+                                case 1:
+                                setParam("waveType", 1);
+                                break;
+
+                                case 2:
+                                setParam("waveType", 2);
+                                break;
+
+                                case 3:
+                                setParam("waveType", 4);
+                                break;
+
+                                case 4:
+                                setParam("waveType", 6);
+                                break;
+
+                                case 5:
+                                setParam("waveType", 8);
+                                break;
+                        }
+
 			setParam("startFrequency", 0.3 + Math.random() * 0.3);
 			setParam("slide", 0.1 + Math.random() * 0.2);
-			
+
 			setParam("sustainTime", 0.1 + Math.random() * 0.3);
 			setParam("decayTime", 0.1 + Math.random() * 0.2);
-			
+
 			if(Math.random() < 0.5) setParam("hpFilterCutoff", Math.random() * 0.3);
 			if(Math.random() < 0.5) setParam("lpFilterCutoff", 1.0 - Math.random() * 0.6);
 		}
-		
+
 		/**
 		 * Sets the parameters to generate a blip/select sound
 		 */
 		public function generateBlipSelect():void
 		{
 			resetParams();
-			
-			setParam("waveType", uint(Math.random() * 2));
-			if(int(getParam("waveType")) == 0) 
-				setParam("squareDuty", Math.random() * 0.6);
-			
+
+                        var wave:int = int(Math.random()*7);
+                        switch (wave)  // Use every wave type, except white and pink noise
+                        {
+                                case 0:
+                                setParam("waveType", 0);
+                                setParam("squareDuty", Math.random() * 0.6);
+                                break;
+
+                                case 1:
+                                setParam("waveType", 1);
+                                break;
+
+                                case 2:
+                                setParam("waveType", 2);
+                                break;
+
+                                case 3:
+                                setParam("waveType", 4);
+                                break;
+
+                                case 4:
+                                setParam("waveType", 6);
+                                break;
+
+                                case 5:
+                                setParam("waveType", 7);
+                                break;
+
+                                case 6:
+                                setParam("waveType", 8);
+                                break;
+                        }
+
 			setParam("startFrequency", 0.2 + Math.random() * 0.4);
-			
+
 			setParam("sustainTime", 0.1 + Math.random() * 0.1);
 			setParam("decayTime", Math.random() * 0.2);
 			setParam("hpFilterCutoff", 0.1);
 		}
-		
+
 		/**
 		 * Resets the parameters, used at the start of each generate function
 		 */
 		public function resetParams(paramsToReset:Array = null):void
 		{
 			paramsDirty = true;
-			
+
 			for (var param:String in _params)
 			{
 				if (paramsToReset==null || paramsToReset.indexOf(param)>=0)
 					_params[param]=getDefault(param);
 			}
-			
+
 			if (paramsToReset==null || paramsToReset.indexOf("lockedParams")>=0)
 			{
 				_lockedParams = new Vector.<String>();
 				//lock this one by default
 				_lockedParams.push("masterVolume");
 			}
-			
+
 		}
-		
+
 		//--------------------------------------------------------------------------
 		//
 		//  Randomize Methods
 		//
 		//--------------------------------------------------------------------------
-		
+
 		/**
 		 * Randomly adjusts the parameters ever so slightly
 		 */
 		public function mutate(mutation:Number = 0.05):void
-		{			
+		{
 			for (var param:String in _params)
 			{
 				if (!lockedParam(param))
@@ -499,10 +688,10 @@ package com.increpare.bfxr.synthesis.Synthesizer
 				}
 			}
 		}
-		
-		//some constants used for weighting random values 
-		
-		private const RandomizationPower:Object = 
+
+		//some constants used for weighting random values
+
+		private const RandomizationPower:Object =
 			{
 				attackTime:4,
 				sustainTime:2,
@@ -517,11 +706,11 @@ package com.increpare.bfxr.synthesis.Synthesizer
 				lpFilterSweep:3,
 				hpFilterCutoff:5,
 				hpFilterSweep:5,
-				bitCrush:4,			
+				bitCrush:4,
 				bitCrushSweep:5
 			}
-			
-		private const WaveTypeWeights:Array = 
+
+		private const WaveTypeWeights:Array =
 			[
 				1,//0:square
 				1,//1:saw
@@ -533,14 +722,14 @@ package com.increpare.bfxr.synthesis.Synthesizer
 				1,//7:whistle
 				1//8:breaker
 			];
-			
+
 		/**
 		 * Sets all parameters to random values
 		 * If passed null, no fields constrained
 		 */
 		public function randomize():void
 		{
-			
+
 			for (var param:String in _params)
 			{
 				if (!lockedParam(param))
@@ -553,9 +742,9 @@ package com.increpare.bfxr.synthesis.Synthesizer
 					_params[param] = min  + (max-min)*r;
 				}
 			}
-			
+
 			paramsDirty = true;
-			
+
 			if (!lockedParam("waveType"))
 			{
 				var count:int=0;
@@ -573,15 +762,15 @@ package com.increpare.bfxr.synthesis.Synthesizer
 						break;
 					}
 				}
-				
+
 			}
-			
+
 			if (!lockedParam("repeatSpeed"))
 			{
 				if (Math.random()<0.5)
 					setParam("repeatSpeed",0);
 			}
-						
+
 			if (!lockedParam("slide"))
 			{
 				r=Math.random()*2-1;
@@ -594,13 +783,13 @@ package com.increpare.bfxr.synthesis.Synthesizer
 				r=Math.pow(r,3);
 				setParam("deltaSlide",r);
 			}
-			
+
 			if (!lockedParam("minFrequency"))
 				setParam("minFrequency",0);
-			
+
 			if (!lockedParam("startFrequency"))
 				setParam("startFrequency",  	(Math.random() < 0.5) ? pow(Math.random()*2-1, 2) : (pow(Math.random() * 0.5, 3) + 0.5));
-			
+
 			if ((!lockedParam("sustainTime")) && (!lockedParam("decayTime")))
 			{
 				if(getParam("attackTime") + getParam("sustainTime") + getParam("decayTime") < 0.2)
@@ -609,56 +798,56 @@ package com.increpare.bfxr.synthesis.Synthesizer
 					setParam("decayTime", 0.2 + Math.random() * 0.3);
 				}
 			}
-			
+
 			if (!lockedParam("slide"))
 			{
-				if((getParam("startFrequency") > 0.7 && getParam("slide") > 0.2) || (getParam("startFrequency") < 0.2 && getParam("slide") < -0.05)) 
+				if((getParam("startFrequency") > 0.7 && getParam("slide") > 0.2) || (getParam("startFrequency") < 0.2 && getParam("slide") < -0.05))
 				{
 					setParam("slide", -getParam("slide"));
 				}
 			}
-			
+
 			if (!lockedParam("lpFilterCutoffSweep"))
 			{
-				if(getParam("lpFilterCutoff") < 0.1 && getParam("lpFilterCutoffSweep") < -0.05) 
+				if(getParam("lpFilterCutoff") < 0.1 && getParam("lpFilterCutoffSweep") < -0.05)
 				{
 					setParam("lpFilterCutoffSweep", -getParam("lpFilterCutoffSweep"));
 				}
 			}
 		}
-		
-		
+
+
 		//--------------------------------------------------------------------------
-		//	
+		//
 		//  Settings String Methods
 		//
 		//--------------------------------------------------------------------------
-		
+
 		/**
 		 * Returns a string representation of the parameters for copy/paste sharing
 		 * @return	A comma-delimited list of parameter values
 		 */
 		public function Serialize():String
-		{			
+		{
 			var string:String="";
 			for (var i:int=0; i< SfxrParams.ParamData.length;i++)
 			{
 				var param:String = SfxrParams.ParamData[i][3];
-				
+
 				if (i>0)
 					string+=",";
-				
-				string += to4DP(getParam(param)); 
+
+				string += to4DP(getParam(param));
 			}
-			
+
 			for (i=0;i<this._lockedParams.length;i++)
 			{
 				string+=","+_lockedParams[i];
 			}
-			
+
 			return string;
 		}
-		
+
 		/**
 		 * Parses a settings string into the parameters
 		 * @param	string	Settings string to parse
@@ -670,30 +859,30 @@ package com.increpare.bfxr.synthesis.Synthesizer
 			{
 				throw new Error("passed null string to SfxrParams.Deserialize");
 			}
-			
+
 			var values:Array = string.split(",");
-			
+
 			var string:String;
 			for (var i:int=0; i< SfxrParams.ParamData.length;i++)
 			{
 				var param:String = SfxrParams.ParamData[i][3];
 				setParam(param,Number(values[i]));
-			}						
-						
+			}
+
 			_lockedParams = new Vector.<String>();
 			for (;i<values.length;i++)
 			{
 				_lockedParams.push(values[i]);
 			}
-		}   
-		
-		
+		}
+
+
 		//--------------------------------------------------------------------------
-		//	
+		//
 		//  Copying Methods
 		//
 		//--------------------------------------------------------------------------
-		
+
 		/**
 		 * Returns a copy of this SfxrParams with all settings duplicated
 		 * @return	A copy of this SfxrParams
@@ -701,11 +890,11 @@ package com.increpare.bfxr.synthesis.Synthesizer
 		public function clone():SfxrParams
 		{
 			var out:SfxrParams = new SfxrParams();
-			out.copyFrom(this);		
-			
+			out.copyFrom(this);
+
 			return out;
 		}
-		
+
 		/**
 		 * Copies parameters from another instance
 		 * @param	params	Instance to copy parameters from
@@ -716,31 +905,31 @@ package com.increpare.bfxr.synthesis.Synthesizer
 			{
 				_params[param] = params.getParam(param);
 			}
-			
+
 			if (makeDirty) paramsDirty = true;
-		}   
-		
-		
+		}
+
+
 		//--------------------------------------------------------------------------
 		//
 		//  Util Methods
 		//
 		//--------------------------------------------------------------------------
-		
+
 		/**
 		 * Clams a value to betwen 0 and 1
 		 * @param	value	Input value
 		 * @return			The value clamped between 0 and 1
 		 */
 		private function clamp1(value:Number):Number { return (value > 1.0) ? 1.0 : ((value < 0.0) ? 0.0 : value); }
-		
+
 		/**
 		 * Clams a value to betwen -1 and 1
 		 * @param	value	Input value
 		 * @return			The value clamped between -1 and 1
 		 */
 		private function clamp2(value:Number):Number { return (value > 1.0) ? 1.0 : ((value < -1.0) ? -1.0 : value); }
-		
+
 		/**
 		 * Clams a value to betwen a and b
 		 * @param	value	Input value
@@ -749,7 +938,7 @@ package com.increpare.bfxr.synthesis.Synthesizer
 		 * @return			The value clamped between min and max
 		 */
 		private function clamp(value:Number, min:Number, max:Number):Number { return (value > max) ? max : ((value < min) ? min : value); }
-		
+
 		/**
 		 * Quick power function
 		 * @param	base		Base to raise to power
@@ -765,11 +954,11 @@ package com.increpare.bfxr.synthesis.Synthesizer
 				case 4: return base*base*base*base;
 				case 5: return base*base*base*base*base;
 			}
-			
+
 			return 1.0;
 		}
-		
-		
+
+
 		/**
 		 * Returns the number as a string to 4 decimal places
 		 * @param	value	Number to convert
@@ -778,18 +967,18 @@ package com.increpare.bfxr.synthesis.Synthesizer
 		private function to4DP(value:Number):String
 		{
 			if (value < 0.0001 && value > -0.0001) return "";
-			
+
 			var string:String = String(value);
 			var split:Array = string.split(".");
-			if (split.length == 1) 	
+			if (split.length == 1)
 			{
 				return string;
 			}
-			else 					
+			else
 			{
 				var out:String = split[0] + "." + split[1].substr(0, 4);
 				while (out.substr(out.length - 1, 1) == "0") out = out.substr(0, out.length - 1);
-				
+
 				return out;
 			}
 		}

--- a/src/com/increpare/bfxr/synthesis/Synthesizer/SfxrParams.as
+++ b/src/com/increpare/bfxr/synthesis/Synthesizer/SfxrParams.as
@@ -399,6 +399,8 @@ package com.increpare.bfxr.synthesis.Synthesizer
                                 setParam("waveType", 5);
                         }
 
+                        setParam("attackTime", Math.random() * 0.6);
+
 			if(Math.random() < 0.5)
 			{
 				setParam("startFrequency", 0.1 + Math.random() * 0.4);


### PR DESCRIPTION
Make better use of the new wave types when you click any of the preset generators.

I used Editra, and it stripped out trailing whitespace, so the edit seems to change a lot, but really it's just the generator methods. It randomizes the voice type for the presets.

line 253 - pickup / coin - Use every wave type, except white or pink noise

line 310 - laser/shoot - Use every wave type, except white or pink noise

line 391 - explosion - Use white or pink noise

line 441 - powerup - Use every wave type, except white and pink noise

line 503 - hit/hurt - Use every wave type

line 560 - jump - Use every wave type, except white noise, pink noise, or tan

line 606 - blip - Use every wave type, except white and pink noise
